### PR TITLE
Remove STAR output path hardcode from workflow.

### DIFF
--- a/fastq/dxworkflow.json
+++ b/fastq/dxworkflow.json
@@ -144,7 +144,6 @@
       "id": "map_reads",
       "executable": "app-stjude_star/1.3.1",
       "name": "STAR alignment",
-      "folder": "/",
       "input": {
         "fastq_r1": {
           "$dnanexus_link": {

--- a/fastq/dxworkflow.json
+++ b/fastq/dxworkflow.json
@@ -2,7 +2,7 @@
   "name": "Rapid RNA-Seq (FastQ)",
   "title": "Rapid RNA-Seq (FastQ)",
   "summary": "A fusion calling pipeline",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "inputs": [
     {
       "name": "fastq_r1",


### PR DESCRIPTION
Currently, the STAR step of Rapid RNA-Seq hardcodes an output path. This overrides any selection from the user and causes the BAM+BAI to potentially be placed in a separate directory from other workflow output.